### PR TITLE
Fix issue where query parameters are encoded twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,7 @@ export default ({
         function generateUrl(params) {
           const formatted = Object.entries(params)
             .filter(([, value]) => value)
-            .reduce((acc, [key, value]) => ({...acc, [key]: encodeURIComponent(value)}), {});
+            .reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
 
           const searchParams = new URLSearchParams(formatted);
           return `${baseUrl}?${searchParams.toString()}`;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -45,7 +45,7 @@ function callback({getFixture, defaultParameters, method, error}) {
   const expectedToken = getFixture('expected-token.json');
 
   let recordCount = 0; // eslint-disable-line functional/no-let
-  const client = createClient({...defaultParameters, url: 'http://foo.bar'});
+  const client = createClient({...defaultParameters, url: 'http://foo.bar', set: 'foo:bar'});
 
   return new Promise((resolve, reject) => {
     client[method.name](method.parameters)

--- a/test-fixtures/index/01/metadata.json
+++ b/test-fixtures/index/01/metadata.json
@@ -9,13 +9,13 @@
   "requests": [
     {
       "method": "get",
-      "url": "/?verb=ListRecords&metadataPrefix=foo",
+      "url": "/?verb=ListRecords&metadataPrefix=foo&set=foo%3Abar",
       "status": 200
     },
     {
       "method": "get",
       "url": "/?verb=ListRecords&resumptionToken=foobar",
       "status": 200
-    }        
-  ]  
+    }
+  ]
 }

--- a/test-fixtures/index/02/metadata.json
+++ b/test-fixtures/index/02/metadata.json
@@ -10,8 +10,8 @@
   "requests": [
     {
       "method": "get",
-      "url": "/?verb=ListRecords&metadataPrefix=foo",
+      "url": "/?verb=ListRecords&metadataPrefix=foo&set=foo%3Abar",
       "status": 200
-    }     
-  ]  
+    }
+  ]
 }

--- a/test-fixtures/index/03/metadata.json
+++ b/test-fixtures/index/03/metadata.json
@@ -9,9 +9,9 @@
   "requests": [
     {
       "method": "get",
-      "url": "/?verb=ListRecords&metadataPrefix=foo",
+      "url": "/?verb=ListRecords&metadataPrefix=foo&set=foo%3Abar",
       "status": 200
-    }     
+    }
   ],
   "error": {
     "code": "cannotDisseminateFormat"

--- a/test-fixtures/index/04/metadata.json
+++ b/test-fixtures/index/04/metadata.json
@@ -10,13 +10,13 @@
   "requests": [
     {
       "method": "get",
-      "url": "/?verb=ListRecords&metadataPrefix=foo",
+      "url": "/?verb=ListRecords&metadataPrefix=foo&set=foo%3Abar",
       "status": 200
     },
     {
       "method": "get",
       "url": "/?verb=ListRecords&resumptionToken=foobar",
       "status": 200
-    }        
-  ]  
+    }
+  ]
 }


### PR DESCRIPTION
This PR fixes issue where set-definitions in format 'foo:bar' result into error because of encoding the character ':' twice. Tests have been updated to cover the scenario that is fixed here.